### PR TITLE
Adicionar .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Opa, boa tarde. O projeto está sem o **.gitignore** então todos os diretórios então subindo para o GitHub, como as dependências _(e suas bibliotecas),_ o que não é muito legal para o repositório.

Valeu! 😊